### PR TITLE
New wallet option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,164 @@
-__pycache__
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+# Custom
 scrtsxx.py
+src/meile_gui.egg-info/*

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,7 @@ googleapis-common-protos==1.59.1
 grpcio==1.51.1
 httplib2==0.22.0
 idna==3.4
+importlib-resources==6.1.0
 jsonschema==4.17.3
 Kivy==2.1.0
 Kivy-Garden==0.1.5
@@ -33,6 +34,7 @@ kivyoav==0.42
 mapview==1.0.6
 pexpect==4.8.0
 Pillow==9.2.0
+pkgutil_resolve_name==1.3.10
 protobuf==4.23.3
 psutil==5.9.3
 ptyprocess==0.7.0
@@ -51,11 +53,14 @@ python-dateutil==2.8.2
 qrcode==7.3.1
 requests==2.28.1
 rsa==4.9
-save-thread-result==0.0.9
+save-thread-result==0.1.1.post1
 screeninfo==0.8.1
 sentinel_protobuf==0.3.1
 six==1.16.0
+stripe==6.7.0
 treelib==1.6.1
+typing_extensions==4.8.0
 Unidecode==1.3.6
 uritemplate==4.1.1
 urllib3==1.26.12
+zipp==3.17.0

--- a/src/kv/meile.kv
+++ b/src/kv/meile.kv
@@ -288,6 +288,11 @@ WindowManager:
                 pos_hint: {'x' : .1 , 'top': .9 }
                 text: "REFRESH"
                 on_release: root.refresh_wallet()
+
+            MDRaisedButton:
+                pos_hint: {'x' : .1 , 'top': .83 }
+                text: "NEW WALLET"
+                on_release: root.open_dialog_new_wallet()
                 
             MDRaisedButton:
                 pos_hint: {'x' : .8 , 'top': .9 }

--- a/src/ui/screens.py
+++ b/src/ui/screens.py
@@ -896,8 +896,11 @@ class WalletScreen(Screen):
 
     def destroy_wallet_open_wallet_dialog(self, _):
         keyring_fpath = path.join(MeileGuiConfig.BASEDIR, "keyring-file")
-        if path.exists(keyring_fpath):
-            rmtree(keyring_fpath)
+        img_fpath = path.join(MeileGuiConfig.BASEDIR, "img")
+
+        for folder_path in [keyring_fpath, img_fpath]:
+            if path.exists(folder_path):
+                rmtree(folder_path)
 
         # Remove also the [wallet] section in config.ini
         # So, if the keyring-file is deleted and the use close accidentaly the application

--- a/src/ui/screens.py
+++ b/src/ui/screens.py
@@ -911,7 +911,8 @@ class WalletScreen(Screen):
             # CONFIG.remove_section('wallet')
             # We had to clear all the data as defaultconf file (can't remove)
             for k in CONFIG["wallet"]:
-                CONFIG.set("wallet", k, "")
+                if k != "uuid":
+                    CONFIG.set("wallet", k, "")
             FILE = open(MeileConfig.CONFFILE, 'w')
             CONFIG.write(FILE)
 


### PR DESCRIPTION
Within the Wallet interface, It's possibile to make a new wallet. A warning message of current wallet destruction with option to continue or cancel apper. Upon continuing the old wallet is removed and the config.ini is altered to remove the wallet name and address in order to prepare for the new wallet. The Restore/Create dialog will be presented to the user giving them the options. The selection will show the same interface as initial wallet creation.