### PR TITLE
Changed UI ticker from DVPN to P2P

### DIFF
--- a/src/fiat/fiat_interface.py
+++ b/src/fiat/fiat_interface.py
@@ -29,7 +29,7 @@ import fiat.stripe_pay.charge as Charge
 from fiat.stripe_pay.dist import scrtsxx
 
 from typedef.win import WindowNames
-from typedef.konstants import HTTParams
+from typedef.konstants import HTTParams, IBCTokens
 from ui.interfaces import TXContent
 from conf.meile_config import MeileGuiConfig
 import main.main as Meile
@@ -121,7 +121,7 @@ class FiatInterface(Screen):
         menu_items = [
             {
                 "viewclass": "OneLineListItem",
-                "text": f"{i}",
+                "text": IBCTokens.COIN_DISPLAY.get(i, i),
                 "height": dp(56),
                 "on_release": lambda x=f"{i}": self.set_token(x),
             } for i in self.TokenOptions
@@ -173,7 +173,7 @@ class FiatInterface(Screen):
                     self.ProcessingDialog("You did not accept the MathNodes purchasing policy.", True, False) 
                     return
             else:
-                self.ProcessingDialog("We could not get an accurate DVPN price at the moment. Please try your order again later.", True, False)
+                self.ProcessingDialog("We could not get an accurate P2P price at the moment. Please try your order again later.", True, False)
                 return 
             
     def DynamicCoinOptions(self):
@@ -254,7 +254,7 @@ class FiatInterface(Screen):
                 }
                     
     def set_token_price(self, token, dt):
-        self.ids.dvpn_price.text = "%s: $" % token.upper() + str(self.get_token_price(token))
+        self.ids.dvpn_price.text = "%s: $" % IBCTokens.COIN_DISPLAY.get(token, token.upper()) + str(self.get_token_price(token))
          
     def get_token_price(self, token):
         try:
@@ -283,7 +283,7 @@ class FiatInterface(Screen):
         except:
             pass 
         
-        self.ids.dvpn_price.text = "%s: $" % token.upper() + str(round(float(token_price)*1.05, 8))
+        self.ids.dvpn_price.text = "%s: $" % IBCTokens.COIN_DISPLAY.get(token, token.upper()) + str(round(float(token_price)*1.05, 8))
         return round(float(token_price)*1.05, 8)
         
         
@@ -483,7 +483,7 @@ class FiatInterface(Screen):
             return STATUS
     
     def set_token(self, text_item):
-        self.ids.token.set_item(text_item)
+        self.ids.token.set_item(IBCTokens.COIN_DISPLAY.get(text_item, text_item))
         self.menu_token.dismiss()
         self.menu_dvpn_qty.clear_widgets()
         self.SelectedCoin = text_item
@@ -567,11 +567,11 @@ class FiatInterface(Screen):
         self.ids.charge_amount.text = "Total Charge: $" + str(round((self.get_token_price(token)*self.get_token_qty(token))+self.GetSurchargeAmount(),2))
         
         if token == self.TokenOptions[0]:
-            self.ids.coin_qty.text = "QTY: " + str(self.DVPNOptions[self.idvpn]) + " " + self.TokenOptions[0]
+            self.ids.coin_qty.text = "QTY: " + str(self.DVPNOptions[self.idvpn]) + " " + IBCTokens.COIN_DISPLAY.get(self.TokenOptions[0], self.TokenOptions[0])
         elif token == self.TokenOptions[1]:
-            self.ids.coin_qty.text = "QTY: " + str(self.DECOptions[self.idvpn]) + " " + self.TokenOptions[1]
+            self.ids.coin_qty.text = "QTY: " + str(self.DECOptions[self.idvpn]) + " " + IBCTokens.COIN_DISPLAY.get(self.TokenOptions[1], self.TokenOptions[1])
         else:
-            self.ids.coin_qty.text = "QTY: " + str(self.SCRTOptions[self.idvpn]) + " " + self.TokenOptions[2]
+            self.ids.coin_qty.text = "QTY: " + str(self.SCRTOptions[self.idvpn]) + " " + IBCTokens.COIN_DISPLAY.get(self.TokenOptions[2], self.TokenOptions[2])
     
     def get_token_qty(self, token):
         if token == self.TokenOptions[0]:

--- a/src/kv/meile.kv
+++ b/src/kv/meile.kv
@@ -2116,9 +2116,9 @@ WindowManager:
         MDDropDownItem:
             id: drop_item
             pos_hint: {'center_x': .5, 'center_y': .5}
-            text: "dvpn"
+            text: "P2P"
             on_release: root.menu.open()
-            
+
         MDLabel:
             id: usd_price
             text: "$0.00"
@@ -2127,7 +2127,7 @@ WindowManager:
             font_size: "14sp"
             font_name: root.get_font()
             text_color: get_color_from_hex(MeileColors.MEILE)
-            
+
 <PlanSubscribeContent>
     orientation: "vertical"
     spacing: "1sp"
@@ -2175,7 +2175,7 @@ WindowManager:
                     font_size: sp(12)
                 TooltipMDIconButton:
                     icon: "help-circle"
-                    tooltip_text: "Pay with Wallet in DVPN or IBC enabled coins"
+                    tooltip_text: "Pay with Wallet in P2P or IBC enabled coins"
 
             MDBoxLayout:
                 orientation: "horizontal"
@@ -2258,7 +2258,7 @@ WindowManager:
         MDDropDownItem:
             id: drop_item
             pos_hint: {'center_x': .5, 'center_y': .5}
-            text: "dvpn"
+            text: "P2P"
             on_release: root.menu.open()
             
         MDLabel:
@@ -2450,7 +2450,7 @@ WindowManager:
                     text_color: get_color_from_hex(MeileColors.MEILE)
                 MDLabel:
                     font_name: "DejaVuSans"
-                    text: "There are two primary ways to receive tokens to purchase dVPN (the currency) subscriptions and utilize the network. 1.) You get the DVPN token on a exchange and send it to your wallet address. Current exchanges are KuCoin, HotBit, Polarity and Osmosis. Once you purchase the tokens on the exchange, you need to withdraw them to your address listed in the wallet section of this app. The tokens should appear within minutes after a withdrawal and you can begin purchasing and subscribing to Sentinel dVPN nodes through Meile. 2.) You can purchase the currency used for Meile dVPN right in our app via the 'RE-FUEL' button within the wallet. These funds will be handled by our servers and the payment processing is handled by Stripe. Once you successfully complete a purchase, your funds should appear in your wallet within minutes of a successful purchase through our app. This is the easiest method to using Meile dVPN."
+                    text: "There are two primary ways to receive tokens to purchase P2P (the currency) subscriptions and utilize the network. 1.) You get the P2P token on a exchange and send it to your wallet address. Current exchanges are KuCoin, HotBit, Polarity and Osmosis. Once you purchase the tokens on the exchange, you need to withdraw them to your address listed in the wallet section of this app. The tokens should appear within minutes after a withdrawal and you can begin purchasing and subscribing to Sentinel dVPN nodes through Meile. 2.) You can purchase the currency used for Meile dVPN right in our app via the 'RE-FUEL' button within the wallet. These funds will be handled by our servers and the payment processing is handled by Stripe. Once you successfully complete a purchase, your funds should appear in your wallet within minutes of a successful purchase through our app. This is the easiest method to using Meile dVPN."
                     size_hint_y: None
                     height: self.texture_size[1]
                     size_hint_x: 1
@@ -2593,7 +2593,7 @@ WindowManager:
                 
                 MDLabel:
                     font_name: "DejaVuSans"
-                    text: "Sentinel is a Layer-1 blockchain within the Cosmos ecosystem. It was founded in 2017, and provides privacy services, such as decentralized VPN to users both of traditional commerce and blockchain enthusiasts. It's native coin ticker is $DVPN. "
+                    text: "Sentinel is a Layer-1 blockchain within the Cosmos ecosystem. It was founded in 2017, and provides privacy services, such as decentralized VPN to users both of traditional commerce and blockchain enthusiasts. It's native coin ticker is $P2P. "
                     size_hint_y: None
                     height: self.texture_size[1]
                     size_hint_x: 1
@@ -2722,7 +2722,7 @@ WindowManager:
                 id: token
                 pos_hint: {"x": .355, "center_y": .60}
                 text_color: get_color_from_hex(MeileColors.MEILE)
-                text: 'dvpn'
+                text: 'P2P'
                 on_release: root.menu_token.open()
                       
             MDDropDownItem:
@@ -2748,7 +2748,7 @@ WindowManager:
                     
             MDLabel:
                 id: dvpn_price
-                text: "DVPN: $" + str(root.get_token_price('dvpn'))
+                text: "P2P: $" + str(root.get_token_price('dvpn'))
                 theme_text_color: "Custom"
                 text_color: get_color_from_hex(MeileColors.MEILE)
                 pos_hint: {"x": .40, "center_y": .48}
@@ -2763,7 +2763,7 @@ WindowManager:
                 font_size: "16sp"
             MDLabel:
                 id: coin_qty
-                text:"QTY: " + str(root.DVPNOptions[root.idvpn]) + " dvpn"
+                text:"QTY: " + str(root.DVPNOptions[root.idvpn]) + " P2P"
                 theme_text_color: "Custom"
                 text_color: get_color_from_hex(MeileColors.MEILE)
                 pos_hint: {"x": .40, "center_y": .38}

--- a/src/typedef/konstants.py
+++ b/src/typedef/konstants.py
@@ -558,6 +558,7 @@ class IBCTokens():
     IBCUNITTOKEN = {'uscrt' : IBCSCRT, 'uatom' : IBCATOM , 'uosmo' : IBCOSMO, 'unam' : IBCNAM, 'udvpn' : 'udvpn', 'tsent' : 'tsent'}
     mu_coins     = ["udvpn", "uscrt", "uosmo", "uatom", "unam"]
     ibc_coins    = ["dvpn", "scrt", "osmo", "atom", "nam"]
+    COIN_DISPLAY = {'dvpn': 'P2P'}
     ibc_mu_coins  = {"tsent" : "tsent", 
                      "dvpn"  : "udvpn", 
                      "scrt"  : "uscrt", 

--- a/src/ui/screens.py
+++ b/src/ui/screens.py
@@ -1894,7 +1894,7 @@ class WalletScreen(Screen):
             self.scrt_text = str(CoinDict['scrt']) + " scrt"
             self.atom_text = str(CoinDict['atom']) + " atom"
             self.osmo_text = str(CoinDict['osmo']) + " osmo"
-            self.dvpn_text = str(CoinDict['dvpn']) + " dvpn"
+            self.dvpn_text = str(CoinDict['dvpn']) + " P2P"
             self.nam_text  = str(CoinDict['nam'])  + " nam"
             #self.dvpn_text = str(CoinDict['tsent']) + " tsent"
             data = [ 
@@ -1912,7 +1912,7 @@ class WalletScreen(Screen):
             self.scrt_text = str("0.0") + " scrt"
             self.atom_text = str("0.0") + " atom"
             self.osmo_text = str("0.0") + " osmo"
-            self.dvpn_text = str("0.0") + " dvpn"
+            self.dvpn_text = str("0.0") + " P2P"
             self.nam_text = str("0.0") + " nam"
             #self.dvpn_text = str("0.0") + " tsent"
             

--- a/src/ui/widgets.py
+++ b/src/ui/widgets.py
@@ -296,12 +296,12 @@ class SubscribeContent(BoxLayout):
         self.price_api = GetPriceAPI()
         self.price_cache = {}
         self.parse_coin_deposit(IBCTokens.ibc_coins[0])
-        
+
         menu_items = [
             {
                 "viewclass": "IconListItem",
                 "icon": "circle-multiple",
-                "text": f"{i}",
+                "text": IBCTokens.COIN_DISPLAY.get(i, i),
                 "height": dp(56),
                 "on_release": lambda x=f"{i}": self.set_item(x),
             } for i in IBCTokens.ibc_coins #+ ['xmr']
@@ -331,8 +331,8 @@ class SubscribeContent(BoxLayout):
         return Config.resource_path(MeileColors.FONT_FACE)
     
     def set_item(self, text_item):
-        self.ids.drop_item.set_item(text_item)
-    
+        self.ids.drop_item.set_item(IBCTokens.COIN_DISPLAY.get(text_item, text_item))
+
         def after_deposit_updated(deposit_text):
             try:
                 amount = float(deposit_text)
@@ -495,7 +495,7 @@ class PlanSubscribeContent(BoxLayout):
             {
                 "viewclass": "IconListItem",
                 "icon": "circle-multiple",
-                "text": f"{i}",
+                "text": IBCTokens.COIN_DISPLAY.get(i, i),
                 "height": dp(56),
                 "on_release": lambda x=f"{i}": self.set_item(x),
             } for i in IBCTokens.ibc_coins
@@ -561,12 +561,12 @@ class PlanSubscribeContent(BoxLayout):
                 self.set_item("arrr")
                 
             else:
-                self.ids.drop_item.text = "dvpn"
+                self.ids.drop_item.text = "P2P"
                 menu_items = [
                     {
                         "viewclass": "IconListItem",
                         "icon": "circle-multiple",
-                        "text": f"{i}",
+                        "text": IBCTokens.COIN_DISPLAY.get(i, i),
                         "height": dp(56),
                         "on_release": lambda x=f"{i}": self.set_item(x),
                     } for i in IBCTokens.ibc_coins
@@ -575,8 +575,8 @@ class PlanSubscribeContent(BoxLayout):
                 self.set_item(IBCTokens.ibc_coins[0])
                 
     def set_item(self, text_item):
-        self.ids.drop_item.set_item(text_item)
-    
+        self.ids.drop_item.set_item(IBCTokens.COIN_DISPLAY.get(text_item, text_item))
+
         def on_deposit_updated(deposit_text):
             match = re.match(r"([0-9]+(?:\.[0-9]+)?)", deposit_text)
             amt = match.groups()[0] if match else 0.0


### PR DESCRIPTION
### UI rebrand from DVPN → P2P:

Files changed (5):

- src/typedef/konstants.py: added COIN_DISPLAY = {'dvpn': 'P2P'} mapping
- src/kv/meile.kv: UI string edits (tooltip, help text, ticker, dropdown defaults, price/QTY labels)
- src/fiat/fiat_interface.py: token dropdown items, dialog message, dynamic price label, QTY label, set_token display all routed through COIN_DISPLAY.get(token, token.upper())
- src/ui/widgets.py: SubscribeContent and PlanSubscribeContent dropdown items + set_item display + the wallet pay-with default text
- src/ui/screens.py: wallet balance row shows P2P suffix

What's preserved:

- udvpn atomic unit untouched everywhere (verified by grep)
- "Meile dVPN" brand intact (window/screen titles, update popup, Stripe merchantName, FAQ headers)
- dVPN as decentralized-VPN terminology kept ("dVPN tunnel", "Sentinel dVPN nodes", "Why is a dVPN better...", "dVPN Credits")
- All internal 'dvpn' denom keys (TokenOptions, ibc_coins, dict keys, price API arguments, regex strings, NodeData "10000dvpn" format) backend payloads still send "token": "dvpn"
- README, CHANGELOG, setup.py, image filenames, external URLs untouched
- print() debug logs still use token.upper()
Python syntax check passes; no udvpn lines appear in the diff.