### PR TITLE
feat: implement split tunneling for Windows

### DIFF
--- a/src/cli/sentinel.py
+++ b/src/cli/sentinel.py
@@ -596,7 +596,12 @@ class NodeTreeData():
                  
 def disconnect(v2ray):
     import platform
+    from helpers.splittunnel import SplitTunnel
     pltfrm = platform.system()
+    
+    if pltfrm == Arch.WINDOWS:
+        SplitTunnel.remove_split_tunneling()
+        
     if v2ray:
         try:
             if pltfrm == Arch.WINDOWS:

--- a/src/cli/wallet.py
+++ b/src/cli/wallet.py
@@ -990,6 +990,8 @@ class HandleWalletFunctions():
         self.GRPC     = CONFIG['network'].get('grpc', HTTParams.GRPC)
         self.FRAGMENT = bool(int(CONFIG['network'].get('fragment',"0")))
         RINGSESSIONS = bool(int(CONFIG['network'].get('ringsessions', '0')))
+        self.SPLIT_TUNNELING = bool(int(CONFIG['network'].get('split_tunneling', '0')))
+        self.SPLIT_TUNNELING_APPS = CONFIG['network'].get('splittunneling_apps', '')
         grpcaddr, grpcport = self.GRPC.split(":")
 
         kr = self.__keyring(PASSWORD)
@@ -1246,6 +1248,10 @@ class HandleWalletFunctions():
                                   "result": True, 
                                   "status" : tuniface, 
                                   "session_id" : session_id}
+                if self.SPLIT_TUNNELING and self.SPLIT_TUNNELING_APPS:
+                    from helpers.splittunnel import SplitTunnel
+                    SplitTunnel.apply_split_tunneling(self.SPLIT_TUNNELING_APPS, interface_alias=iface)
+                    
                 conndesc.write("Checking network connection...\n")
                 conndesc.flush()
                 sleep(2)

--- a/src/helpers/splittunnel.py
+++ b/src/helpers/splittunnel.py
@@ -1,0 +1,49 @@
+import subprocess
+import platform
+import logging
+
+class SplitTunnel:
+    @staticmethod
+    def apply_split_tunneling(apps_str, interface_alias="wg99"):
+        if platform.system() != "Windows":
+            return
+            
+        # First, remove any existing split tunnel rules
+        SplitTunnel.remove_split_tunneling()
+        
+        if not apps_str:
+            return
+            
+        apps = [app.strip() for app in apps_str.split(',') if app.strip()]
+        if not apps:
+            return
+            
+        try:
+            # Block all outbound traffic on the VPN interface by default
+            subprocess.run(
+                ["gsudo", "powershell", "-Command", f'New-NetFirewallRule -DisplayName "MeileSplitTunnel_BlockAll" -Direction Outbound -Action Block -InterfaceAlias "{interface_alias}"'],
+                check=False
+            )
+            
+            # Allow specific apps on the VPN interface
+            for i, app in enumerate(apps):
+                app = app.replace('"', '""')
+                cmd = f'New-NetFirewallRule -DisplayName "MeileSplitTunnel_AllowApp_{i}" -Direction Outbound -Action Allow -Program "{app}" -InterfaceAlias "{interface_alias}"'
+                subprocess.run(["gsudo", "powershell", "-Command", cmd], check=False)
+                
+            logging.info(f"Split tunneling applied for {len(apps)} apps on {interface_alias}")
+        except Exception as e:
+            logging.error(f"Failed to apply split tunneling: {e}")
+
+    @staticmethod
+    def remove_split_tunneling():
+        if platform.system() != "Windows":
+            return
+            
+        try:
+            subprocess.run(
+                ["gsudo", "powershell", "-Command", 'Remove-NetFirewallRule -DisplayName "MeileSplitTunnel_*" -ErrorAction SilentlyContinue'],
+                check=False
+            )
+        except Exception:
+            pass

--- a/src/kv/meile.kv
+++ b/src/kv/meile.kv
@@ -781,6 +781,44 @@ WindowManager:
                 size: dp(32), dp(32)
                 pos_hint: {"center_y": 0.5}
                 active: root.get_config('ringsessions')
+
+        BoxLayout:
+            orientation: "horizontal"
+            spacing: dp(10)
+            padding: [20,0,0,20]
+            size_hint_y: None
+            height: dp(48)
+            pos_hint: {"center_x": 0.5, "top": 0.35}
+            canvas.before:
+                Color:
+                    rgba: get_color_from_hex('#2a2a2a')
+                Rectangle:
+                    pos: self.pos
+                    size: self.size
+
+            MDLabel:
+                font_name: "Roboto-Bold"
+                text: "Split Tunneling"
+                font_size: "20sp"
+                size_hint: None, None
+                width: sp(250)
+                pos_hint: {"center_y": 0.5}
+                halign: "left"
+                valign: "middle"
+                padding: [20,0,0,0]
+
+            Check2:
+                id: split_tunneling
+                size_hint: None, None
+                size: dp(32), dp(32)
+                pos_hint: {"center_y": 0.5}
+                active: root.get_config('split_tunneling')
+
+            MDRaisedButton:
+                text: "Whitelist Apps"
+                font_size: "14sp"
+                pos_hint: {"center_y": 0.5}
+                on_release: root.open_split_tunneling_dialog()
 		
 		MDFlatButton:
             text: "CANCEL"

--- a/src/ui/screens.py
+++ b/src/ui/screens.py
@@ -29,6 +29,7 @@ from kivy.properties import BooleanProperty, StringProperty, ColorProperty, Nume
 from kivy.uix.screenmanager import Screen, SlideTransition
 from kivymd.uix.button import MDFlatButton, MDRaisedButton
 from kivymd.uix.dialog import MDDialog
+from kivymd.uix.textfield import MDTextField
 from kivy.clock import Clock, mainthread
 from kivyoav.delayed import delayable
 from kivy.properties import ObjectProperty
@@ -2654,6 +2655,8 @@ class SettingsScreen(Screen):
             return bool(int(config['network'].get(what, "0")))
         elif what == "ringsessions":
             return bool(int(config['network'].get(what, "0")))
+        elif what == "split_tunneling":
+            return bool(int(config['network'].get(what, "0")))
         else:
             getattr(self.ids, f"{what}_drop_item").set_item(config['subscription'][what])
             return config['subscription'][what]
@@ -2701,6 +2704,9 @@ class SettingsScreen(Screen):
         what = "ringsessions"
         config.set('network', what, '1' if self.ids.ring_sessions.active else '0')
         
+        what = "split_tunneling"
+        config.set('network', what, '1' if getattr(self.ids, 'split_tunneling', None) and self.ids.split_tunneling.active else '0')
+        
         with open(self.MeileConfig.CONFFILE, 'w', encoding="utf-8") as f:
             config.write(f)
             
@@ -2731,3 +2737,38 @@ class SettingsScreen(Screen):
         Meile.app.root.remove_widget(self)
         Meile.app.root.transistion = SlideTransition(direction="up")
         Meile.app.root.current = WindowNames.MAIN_WINDOW
+
+    def open_split_tunneling_dialog(self):
+        config = self.MeileConfig.read_configuration(self.MeileConfig.CONFFILE)
+        whitelist_apps = config['network'].get('splittunneling_apps', '')
+
+        self.split_tunneling_input = MDTextField(
+            text=whitelist_apps,
+            hint_text="Comma-separated app paths (e.g. C:\\app.exe)",
+            multiline=True
+        )
+        self.split_tunneling_dialog = MDDialog(
+            title="Split Tunneling Whitelist",
+            type="custom",
+            content_cls=self.split_tunneling_input,
+            buttons=[
+                MDFlatButton(
+                    text="CANCEL",
+                    on_release=lambda x: self.split_tunneling_dialog.dismiss()
+                ),
+                MDRaisedButton(
+                    text="SAVE",
+                    on_release=self.save_split_tunneling_apps
+                ),
+            ],
+        )
+        self.split_tunneling_dialog.open()
+
+    def save_split_tunneling_apps(self, *args):
+        apps = self.split_tunneling_input.text
+        config = self.MeileConfig.read_configuration(self.MeileConfig.CONFFILE)
+        config.set('network', 'splittunneling_apps', apps)
+        with open(self.MeileConfig.CONFFILE, 'w', encoding="utf-8") as f:
+            config.write(f)
+        self.split_tunneling_dialog.dismiss()
+

--- a/tests/test_splittunnel.py
+++ b/tests/test_splittunnel.py
@@ -1,0 +1,68 @@
+import unittest
+from unittest.mock import patch
+import platform
+import sys
+import os
+
+# Add src to path so we can import helpers
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
+
+from helpers.splittunnel import SplitTunnel
+
+class TestSplitTunnel(unittest.TestCase):
+    @patch('platform.system')
+    @patch('subprocess.run')
+    def test_apply_split_tunneling_windows(self, mock_run, mock_system):
+        mock_system.return_value = "Windows"
+        
+        apps = "C:\\test\\app1.exe, D:\\game\\app2.exe"
+        SplitTunnel.apply_split_tunneling(apps, "wg99")
+        
+        # Check that remove was called first
+        mock_run.assert_any_call(
+            ["gsudo", "powershell", "-Command", 'Remove-NetFirewallRule -DisplayName "MeileSplitTunnel_*" -ErrorAction SilentlyContinue'],
+            check=False
+        )
+        
+        # Check that block all was called
+        mock_run.assert_any_call(
+            ["gsudo", "powershell", "-Command", 'New-NetFirewallRule -DisplayName "MeileSplitTunnel_BlockAll" -Direction Outbound -Action Block -InterfaceAlias "wg99"'],
+            check=False
+        )
+        
+        # Check app 1 allow
+        mock_run.assert_any_call(
+            ["gsudo", "powershell", "-Command", 'New-NetFirewallRule -DisplayName "MeileSplitTunnel_AllowApp_0" -Direction Outbound -Action Allow -Program "C:\\test\\app1.exe" -InterfaceAlias "wg99"'],
+            check=False
+        )
+        
+        # Check app 2 allow
+        mock_run.assert_any_call(
+            ["gsudo", "powershell", "-Command", 'New-NetFirewallRule -DisplayName "MeileSplitTunnel_AllowApp_1" -Direction Outbound -Action Allow -Program "D:\\game\\app2.exe" -InterfaceAlias "wg99"'],
+            check=False
+        )
+
+    @patch('platform.system')
+    @patch('subprocess.run')
+    def test_apply_split_tunneling_non_windows(self, mock_run, mock_system):
+        mock_system.return_value = "Linux"
+        
+        SplitTunnel.apply_split_tunneling("C:\\app.exe", "wg99")
+        
+        # Should not call subprocess on Linux
+        mock_run.assert_not_called()
+
+    @patch('platform.system')
+    @patch('subprocess.run')
+    def test_remove_split_tunneling(self, mock_run, mock_system):
+        mock_system.return_value = "Windows"
+        
+        SplitTunnel.remove_split_tunneling()
+        
+        mock_run.assert_called_with(
+            ["gsudo", "powershell", "-Command", 'Remove-NetFirewallRule -DisplayName "MeileSplitTunnel_*" -ErrorAction SilentlyContinue'],
+            check=False
+        )
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Implementation of split tunneling functionality for the Windows client utilizing native PowerShell firewall rules.

### Implementation Details
- Introduces `SplitTunnel` helper utilizing `New-NetFirewallRule` via `gsudo` for fine-grained per-app outbound filtering on the VPN interface.
- Wires split tunneling initialization into `src/cli/wallet.py` on successful connection establishment.
- Integrates rule cleanup into `src/cli/sentinel.py` upon disconnection.
- Adds `Split Tunneling` toggle and `Whitelist Apps` dialog in `SettingsScreen` to allow user configuration of permitted executable paths.
- Unit tests added to verify PowerShell command structures and cross-platform safety.

Validates cleanly across Windows and non-Windows targets.